### PR TITLE
Minu

### DIFF
--- a/lib/AuthManager.dart
+++ b/lib/AuthManager.dart
@@ -5,13 +5,20 @@ import './UserManager.dart';
 
 class AuthManager {
   //회원 등록
-  bool registerUser(String userId, String userPwd) {
+  Future<bool> registerUser(String userId, String userPwd) async {
     DatabaseReference ref = FirebaseDatabase.instance.ref("users/$userId");
-    User user = User(userId, userPwd);
+    final snapshot = await ref.get(); //userId경로에서 스냅샷 가져오고
 
-    ref.set({"userId": user.userId, "userPwd": user.userPwd});
-    print("회원가입 성공!");
-    return true;
+    if (snapshot.exists) {
+      //userId가 이미 존재한다면 (회원가입 안됨, 이미 존재하는 id)
+      print("이미 존재하는 ID입니다.");
+      return false;
+    } else {
+      User user = User(userId, userPwd);
+      ref.set({"userId": user.userId, "userPwd": user.userPwd});
+      print("회원가입 성공");
+      return true;
+    }
   }
 
   //로그인

--- a/lib/Controller/GetFilteredFeeds.dart
+++ b/lib/Controller/GetFilteredFeeds.dart
@@ -5,8 +5,11 @@ import 'package:http/http.dart' as http;
 import '../News.dart';
 
 /*
-관련된 기사를 가져오고, 그 기사 리스트를 반환하는 함수
- */
+* 이 함수는 키워드와 관련된 뉴스정보를 전달받는다(title, link, published)
+* API요청하면 body에 userId를 실어서 보낸다.
+* 요청된 python에서는 전달받은 userId를 활용해 DB에서 userId에 저장된 키워드 리스트
+* 불러오고, 그 키워드 리스트들과 관련된 뉴스만 필터링해서 response한다.
+*  */
 Future<List<dynamic>> getFilteredFeeds() async {
   String? userId = getLoggedInUserId();
   final response = await http.post(

--- a/lib/Controller/GetSummary.dart
+++ b/lib/Controller/GetSummary.dart
@@ -1,5 +1,11 @@
 import 'package:http/http.dart' as http;
 
+/*
+* 이 함수는 요약본을 제공하는 함수임
+* API를 호출하며 body에 link를 실어서 보낸다.
+* 요청된 python 함수에서는 전달받은 link에서 원문을 추출하고
+* 요약본을 response로 제공해준다.
+* */
 Future<String> getSummary(String newsLink) async {
   String? link = newsLink;
 

--- a/lib/KeywordManager.dart
+++ b/lib/KeywordManager.dart
@@ -5,15 +5,15 @@ import './Keyword.dart';
 import './UserManager.dart';
 
 class KeywordManager {
-  final User user;
+  String userId;
 
   //생성자
-  KeywordManager(this.user);
+  KeywordManager(this.userId); //생성자에 userId넣어야함 getLoggedInUserId()전역함수 사용
 
   //키워드 추가(json형식으로 저장)
   Future<void> addKeyword(Keyword keyWord) async {
     DatabaseReference ref = FirebaseDatabase.instance
-        .ref("users/${this.user.userId}/keywords")
+        .ref("users/${this.userId}/keywords")
         .push();
 
     Map<String, String> mapKeyword = {
@@ -29,7 +29,7 @@ class KeywordManager {
 
   Future<void> removeKeyword(Keyword keyWord) async {
     DatabaseReference ref =
-        FirebaseDatabase.instance.ref("users/${this.user.userId}/keywords");
+        FirebaseDatabase.instance.ref("users/${this.userId}/keywords");
 
     final snapshot = await ref.get();
     if (snapshot.exists) {
@@ -54,7 +54,7 @@ class KeywordManager {
   //키워드 활성화
   Future<void> activateKeyword(Keyword keyWord) async {
     DatabaseReference ref =
-        FirebaseDatabase.instance.ref("users/${this.user.userId}/keywords");
+        FirebaseDatabase.instance.ref("users/${this.userId}/keywords");
 
     final snapshot = await ref.get();
 
@@ -78,7 +78,7 @@ class KeywordManager {
   //키워드 비활성화
   Future<void> deactivateKeyword(Keyword keyWord) async {
     DatabaseReference ref =
-        FirebaseDatabase.instance.ref("users/${this.user.userId}/keywords");
+        FirebaseDatabase.instance.ref("users/${this.userId}/keywords");
 
     final snapshot = await ref.get();
     if (snapshot.exists) {


### PR DESCRIPTION
### Before

키워드 추가할 때, KeywordManager 객체 생성시 User객체를 인자로 전달해야했었음
-> KeywordManager 객체 생성할 때, 생성자를 불러올 시 User객체를 전달해야함

### Now
KeywordManager 객체 생성시에, global.dart에 있는, getLoggedInUserId()함수를 사용한다.
-> KeywordManager 객체 생성할 때, 생성자를 불러올 시 getLoggedInUserId()로 userId를 인자로 전달하기만 하면 됨
